### PR TITLE
action mailerの修正アップデートで送信に変更

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,13 +49,13 @@ class UsersController < ApplicationController
   def reservation_confirmed_mail
     @work_reservation = WorkReservation.find(params[:id])
      respond_to do |format|
-      if @work_reservation.present?
-        UserMailer.with(work: @work_reservation).welcome_email.deliver_later
+      if @work_reservation.update_attributes(finished_mail_params)
+        UserMailer.with(work_reservation: @work_reservation).welcome_email.deliver_now
         format.html { redirect_to(@work_reservation, notice: 'お客様に予約内容を送信しました。') }
-        format.json { render json: @work_reservation, status: :created, location: @work_reservation }
+        format.text { redirect_to(@work_reservation, notice: 'お客様に予約内容を送信しました。') }
+        flash[:success] = "お客様に予約内容を送信しました。"
       else
         format.html { render action: 'new' }
-        format.json { render json: @work_reservation.errors, status: :unprocessable_entity }
       end
      end
   end
@@ -78,7 +78,7 @@ class UsersController < ApplicationController
       end
 
       def finished_mail_params
-        params.require(:work_reservation).permit({main_menu: []}, {option_menu: []}, :reservation_work, :worked_on, :start_times, :user_id)
+        params.require(:work_reservation).permit(:reservation_mark)
       end
 
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,7 +3,7 @@ class UserMailer < ApplicationMailer
 
   def welcome_email
     @url  = 'https://nagomi-system.herokuapp.com/staffs/sign_in'
-    @work_reservation = params[:work]
+    @work_reservation = params[:work_reservation]
     mail(to: @work_reservation.user.email, subject: "予約確定のお知らせ")
   end
 end

--- a/app/views/users/_edit_reservation_status.html.erb
+++ b/app/views/users/_edit_reservation_status.html.erb
@@ -17,6 +17,12 @@
               </thead>
 
               <tbody>
+                 <% if work_reservation.reservation_mark.present?%>
+                   <tr><th colspan="2">送信確認</th><td colspan="2">お客様に予約メールを送信済み</td></tr>
+                 <% else %>
+                   <tr><th colspan="2">送信確認</th><td colspan="2">お客様に予約メールを未送信</td></tr>
+                 <%end%>
+
                  <tr><th colspan="2">名前</th><td colspan="2"><%= work_reservation.user.name %></td></tr>
                  <tr><th colspan="2">TEL</th><td colspan="2"><%= work_reservation.user.phone_number %></td></tr>
                  <tr><th colspan="2">住所</th><td colspan="2"><%= work_reservation.user.address %></td></tr>

--- a/app/views/users/reservation_confirmed.html.erb
+++ b/app/views/users/reservation_confirmed.html.erb
@@ -18,7 +18,9 @@
        訪問日：<%= @work_reservation.worked_on.to_s(:date) %></br>
        作業開始時間：<%= @work_reservation.start_times.to_s(:hour) %>時<%= @work_reservation.start_times.to_s(:min) %>分</br>
 
-     <%= form_with(model: @work_reservation, url: reservation_confirmed_mail_user_path(@work_reservation), local: true, method: :get) do |f| %>
+     <%= form_with(model: @work_reservation, url: reservation_confirmed_mail_user_path(@work_reservation), local: true, method: :patch) do |f| %>
+       <%= f.label :送信許可, class: "label-#{yield(:class_text)}" %>
+       <%= f.check_box :reservation_mark ,{}, "true", "false" %></br>
        <%= f.submit "以上の内容をお客様へ送信する", data: { confirm: "メールを送信してもよろしいですか？" }, class: "btn btn-primary" %>
      <% end %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
       get 'new_work_reservation'  #予約状況新規作成ページ行き
       get 'show_account'
       get 'reservation_confirmed' #メール内容確認ページ行き
-      get 'reservation_confirmed_mail' #メール送信処理
+      patch 'reservation_confirmed_mail' #メール送信処理
     end
   end
   resources :staffs do


### PR DESCRIPTION
## やったこと

* action mailerの送信に許可のチェックボックスを追加し、送信条件をただの送信からアップデートした時に変更。

## やらないこと

* 無し

## できるようになること（ユーザ目線）

* 修正のみ挙動は変わらず。

## できなくなること（ユーザ目線）

* 無し

## 動作確認

* 送信後に予約状況に送信済の記載を追加。

## その他
